### PR TITLE
Add support for missing HTTP methods

### DIFF
--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -113,7 +113,7 @@ impl fmt::Display for HttpRequest {
 }
 
 pub(crate) fn parse_http_method(s: &str) -> ParseHttpRequestResult<HttpMethod> {
-    if s == "GET" || s == "POST" || s == "DELETE" || s == "HEAD" {
+    if s == "GET" || s == "POST" || s == "DELETE" || s == "HEAD" || s == "PUT" || s == "PATCH" {
         Ok(s.to_string())
     } else {
         Err(ParseHttpRequestError::ParseHttpMethod)


### PR DESCRIPTION
Hi,

If log lines include the HTTP methods HTTP or PATCH, we would get Record Error during the parsing of HTTP method. 

